### PR TITLE
Only add downlight when not None (eg. Halo)

### DIFF
--- a/custom_components/chargeamps/__init__.py
+++ b/custom_components/chargeamps/__init__.py
@@ -192,7 +192,7 @@ class ChargeampsHandler:
         if dimmer is not None:
             settings.dimmer = dimmer.capitalize()
         if downlight is not None:
-            settings.down_light = downlight
+            settings.downlight = downlight
         if self.readonly:
             _LOGGER.info("NOT setting chargepoint: %s", settings)
         else:

--- a/custom_components/chargeamps/client.py
+++ b/custom_components/chargeamps/client.py
@@ -72,7 +72,7 @@ class ChargePointStatus:
 class ChargePointSettings:
     id: str
     dimmer: str
-    down_light: bool
+    downlight: bool | None = None
 
 
 @dataclass_json(letter_case=LetterCase.CAMEL)

--- a/custom_components/chargeamps/light.py
+++ b/custom_components/chargeamps/light.py
@@ -23,12 +23,14 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
         cp_settings = handler.get_chargepoint_settings(cp_id)
         _LOGGER.debug("%s", cp_settings)
         for _type in ("dimmer", "downlight"):
-            lights.append(ChargeampsLight(hass, f"{cp_info.name}_{cp_id}_{_type}", cp_id, _type))
-            _LOGGER.info(
-                "Adding chargepoint %s light %s",
-                cp_id,
-                _type,
-            )
+            val = getattr(cp_settings, _type, None) if cp_settings else None
+            if val is not None:
+                lights.append(ChargeampsLight(hass, f"{cp_info.name}_{cp_id}_{_type}", cp_id, _type))
+                _LOGGER.info(
+                    "Adding chargepoint %s light %s",
+                    cp_id,
+                    _type,
+                )
     async_add_entities(lights, True)
 
 
@@ -57,12 +59,12 @@ class ChargeampsLight(LightEntity, ChargeampsEntity):
     def is_on(self):
         settings = self.handler.get_chargepoint_settings(self.charge_point_id)
         if self._light_type == "downlight":
-            status = settings.down_light
+            status = settings.downlight
         elif self._light_type == "dimmer":
             status = settings.dimmer
         else:
             return None
-        return status not in (False, "Off")
+        return status not in (False, None, "Off")
 
     async def async_turn_on(self, brightness=None):
         if brightness:


### PR DESCRIPTION
Add only downlight when halo.

Pick resolution for #64 (firmware and hardware version), not merged to main.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed downlight mapping so its reported state and controls correctly reflect the actual device downlight setting.
  * Prevented creation of light entities when the device lacks the related settings, avoiding non-functional or misleading entries in the UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->