### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -4,6 +4,9 @@ on:
   - push
   - pull_request
 
+permissions:
+  contents: read
+
 jobs:
   ruff:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/hass-chargeamps/hass-chargeamps/security/code-scanning/1](https://github.com/hass-chargeamps/hass-chargeamps/security/code-scanning/1)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is constrained to least privilege.  
Best fix here: define workflow-level permissions right after `on:` (or before `jobs:`) with:

- `contents: read`

This is sufficient for `actions/checkout` and read-only linting steps, and preserves existing functionality.  
Only edit `.github/workflows/ruff.yml`, inserting the new block without altering job logic or action versions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced security configuration for continuous integration processes by implementing principle of least privilege for workflow permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->