### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/hassfest.yaml
+++ b/.github/workflows/hassfest.yaml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: "ubuntu-latest"


### PR DESCRIPTION
Potential fix for [https://github.com/hass-chargeamps/hass-chargeamps/security/code-scanning/2](https://github.com/hass-chargeamps/hass-chargeamps/security/code-scanning/2)

Add an explicit `permissions` block to the workflow so the `GITHUB_TOKEN` is constrained to least privilege.  
Best fix here: define workflow-level permissions with `contents: read`, since the shown jobs only need repository read access (`actions/checkout` + validation action). This avoids changing behavior while hardening security.

**File to edit:** `.github/workflows/hassfest.yaml`  
**Change region:** near the top-level keys (`name`, `on`, `jobs`)  
**Implementation detail:** insert:

```yaml
permissions:
  contents: read
```

between `on:` and `jobs:` (or any top-level location), so it applies to all jobs unless overridden.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD permissions configuration for enhanced security practices.

---

*Note: This is an internal infrastructure update with no user-facing changes.*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->