### PR TITLE
Zero amps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,7 @@ venv
 .HA_VERSION
 home-assistant.log
 home-assistant_v2.db*
+local-docs/
 Charge_Amps_External_Api_version_4.0.pdf
+.env
+.claude/

--- a/custom_components/chargeamps/__init__.py
+++ b/custom_components/chargeamps/__init__.py
@@ -149,6 +149,10 @@ def setup_services(hass: HomeAssistant) -> None:
         conn_id = call.data["connector"]
         max_curr = call.data["max_current"]
 
+        if 0 < max_curr < 6:
+            _LOGGER.error("Invalid max_current %s: must be 0 or between 6 and 32", max_curr)
+            return
+
         if coordinator := await get_coordinator(cp_id):
             settings = coordinator.data["connector_settings"].get((cp_id, conn_id))
             if settings:

--- a/custom_components/chargeamps/number.py
+++ b/custom_components/chargeamps/number.py
@@ -29,7 +29,7 @@ NUMBERS: tuple[ChargeampsNumberEntityDescription, ...] = (
         native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
         device_class="current",
         mode=NumberMode.BOX,
-        native_min_value=6,
+        native_min_value=0,
         native_max_value=32,
         native_step=1,
         entity_category=EntityCategory.CONFIG,
@@ -65,10 +65,12 @@ class ChargeampsNumber(ChargeAmpsEntity, NumberEntity):
     def native_value(self) -> float:
         """Return the current maximum current setting."""
         settings = self.coordinator.data["connector_settings"].get((self.charge_point_id, self.connector_id))
-        return float(settings.max_current) if settings and settings.max_current else 6.0
+        return float(settings.max_current) if settings and settings.max_current is not None else 6.0
 
     async def async_set_native_value(self, value: float) -> None:
         """Set the maximum current."""
+        if 0 < value < 6:
+            raise ValueError(f"Invalid max_current {value}: must be 0 or between 6 and 32")
         settings = self.coordinator.data["connector_settings"].get((self.charge_point_id, self.connector_id))
         if settings:
             settings.max_current = value

--- a/custom_components/chargeamps/services.yaml
+++ b/custom_components/chargeamps/services.yaml
@@ -38,8 +38,7 @@ set_max_current:
       name: Max current
       description: >
         The maximum current used for the charging process in A. Allowed are
-        values between 6 A and 63 A. Invalid values are discarded and the
-        default is set to 6 A.
+        0 A (to pause charging) or values between 6 A and 32 A.
       example: 16
 
 enable:


### PR DESCRIPTION
Allow 0 A as valid chargelevel to effectively pause charging without aborting it. Adressing #103

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved max current validation to prevent invalid values (1–5A now rejected with error messaging)
  * Max current range updated to allow 0A for pausing or 6–32A (previously accepted values up to 63A)

* **Chores**
  * Updated project configuration files

<!-- end of auto-generated comment: release notes by coderabbit.ai -->