### PR TITLE
Fix total energy sensor resetting to 0 between sessions

### DIFF
--- a/custom_components/chargeamps/button.py
+++ b/custom_components/chargeamps/button.py
@@ -29,6 +29,11 @@ BUTTONS: tuple[ChargeampsButtonEntityDescription, ...] = (
         device_class="restart",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
+    ChargeampsButtonEntityDescription(
+        key="recalculate_total_energy",
+        translation_key="recalculate_total_energy",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
 )
 
 
@@ -57,5 +62,8 @@ class ChargeampsButton(ChargeAmpsEntity, ButtonEntity):
 
     async def async_press(self) -> None:
         """Handle the button press."""
-        _LOGGER.info("Rebooting chargepoint %s", self.charge_point_id)
-        await self.coordinator.client.reboot(self.charge_point_id)
+        if self.entity_description.key == "reboot":
+            _LOGGER.info("Rebooting chargepoint %s", self.charge_point_id)
+            await self.coordinator.client.reboot(self.charge_point_id)
+        elif self.entity_description.key == "recalculate_total_energy":
+            await self.coordinator.recalculate_total_energy(self.charge_point_id)

--- a/custom_components/chargeamps/coordinator.py
+++ b/custom_components/chargeamps/coordinator.py
@@ -32,6 +32,7 @@ class ChargeAmpsDataUpdateCoordinator(DataUpdateCoordinator):
         """Initialize."""
         self.client = client
         self._chargepoint_ids = chargepoint_ids or []
+        self._total_energy_max: dict[str, float] = {}
         super().__init__(
             hass,
             _LOGGER,
@@ -79,9 +80,13 @@ class ChargeAmpsDataUpdateCoordinator(DataUpdateCoordinator):
                 for i, conn in enumerate(cp.connectors):
                     data["connector_settings"][(cp.id, conn.connector_id)] = conn_settings_results[i]
 
-                # Calculate total energy from connector statuses (more efficient than fetching all sessions)
-                total_energy = sum(conn_status.total_consumption_kwh for conn_status in status.connector_statuses)
-                data["total_energy"][cp.id] = round(total_energy, 2)
+                # Calculate total energy — use a high watermark so the sensor doesn't
+                # drop to 0 between sessions (total_consumption_kwh resets per session).
+                live_total = round(sum(cs.total_consumption_kwh for cs in status.connector_statuses), 2)
+                prev_max = self._total_energy_max.get(cp.id, 0.0)
+                if live_total > prev_max:
+                    self._total_energy_max[cp.id] = live_total
+                data["total_energy"][cp.id] = self._total_energy_max[cp.id]
 
             # Process all charge points in parallel
             await asyncio.gather(*(fetch_cp_data(cp) for cp in chargepoints))
@@ -90,3 +95,28 @@ class ChargeAmpsDataUpdateCoordinator(DataUpdateCoordinator):
         except Exception as error:
             _LOGGER.exception("Error updating Chargeamps data")
             raise UpdateFailed(f"Error communicating with API: {error}") from error
+
+    async def recalculate_total_energy(self, charge_point_id: str) -> float:
+        """Recompute total energy from the full session history in the Charge Amps API.
+
+        Sums all completed sessions plus any ongoing session energy from the live
+        status, then updates the high watermark so subsequent polls don't overwrite it.
+        """
+        sessions = await self.client.get_all_chargingsessions(charge_point_id)
+        completed_ids = {s.id for s in sessions if s.end_time is not None}
+        completed_total = sum(s.total_consumption_kwh for s in sessions if s.end_time is not None)
+
+        # Add energy for any active session not yet recorded as completed
+        active_total = 0.0
+        status = self.data["status"].get(charge_point_id)
+        if status:
+            for cs in status.connector_statuses:
+                if cs.session_id not in completed_ids:
+                    active_total += cs.total_consumption_kwh or 0.0
+
+        total = round(completed_total + active_total, 2)
+        self._total_energy_max[charge_point_id] = max(total, self._total_energy_max.get(charge_point_id, 0.0))
+        self.data["total_energy"][charge_point_id] = self._total_energy_max[charge_point_id]
+        self.async_set_updated_data(self.data)
+        _LOGGER.info("Recalculated total energy for %s: %.2f kWh", charge_point_id, self._total_energy_max[charge_point_id])
+        return self._total_energy_max[charge_point_id]

--- a/custom_components/chargeamps/sensor.py
+++ b/custom_components/chargeamps/sensor.py
@@ -6,6 +6,7 @@ import logging
 from dataclasses import dataclass
 
 from homeassistant.components.sensor import (
+    RestoreSensor,
     SensorDeviceClass,
     SensorEntity,
     SensorEntityDescription,
@@ -194,7 +195,7 @@ class ChargeampsConnectorSensor(ChargeAmpsEntity, SensorEntity):
         return attrs
 
 
-class ChargeampsChargePointSensor(ChargeAmpsEntity, SensorEntity):
+class ChargeampsChargePointSensor(ChargeAmpsEntity, RestoreSensor):
     """Chargeamps ChargePoint Sensor class."""
 
     entity_description: ChargeampsSensorEntityDescription
@@ -204,6 +205,20 @@ class ChargeampsChargePointSensor(ChargeAmpsEntity, SensorEntity):
         super().__init__(coordinator, charge_point_id)
         self.entity_description = description
         self._attr_unique_id = f"{DOMAIN}_{charge_point_id}_{description.key}"
+
+    async def async_added_to_hass(self) -> None:
+        """Restore last known state into the coordinator watermark on startup."""
+        await super().async_added_to_hass()
+        if self.entity_description.key == "total_energy":
+            if last := await self.async_get_last_sensor_data():
+                try:
+                    restored = float(last.native_value)
+                except (TypeError, ValueError):
+                    return
+                cp_id = self.charge_point_id
+                if restored > self.coordinator._total_energy_max.get(cp_id, 0.0):
+                    self.coordinator._total_energy_max[cp_id] = restored
+                    self.coordinator.data["total_energy"][cp_id] = restored
 
     @property
     def native_value(self) -> float | None:

--- a/custom_components/chargeamps/sensor.py
+++ b/custom_components/chargeamps/sensor.py
@@ -209,8 +209,7 @@ class ChargeampsChargePointSensor(ChargeAmpsEntity, RestoreSensor):
     async def async_added_to_hass(self) -> None:
         """Restore last known state into the coordinator watermark on startup."""
         await super().async_added_to_hass()
-        if self.entity_description.key == "total_energy":
-            if last := await self.async_get_last_sensor_data():
+        if self.entity_description.key == "total_energy" and (last := await self.async_get_last_sensor_data()):
                 try:
                     restored = float(last.native_value)
                 except (TypeError, ValueError):

--- a/custom_components/chargeamps/sensor.py
+++ b/custom_components/chargeamps/sensor.py
@@ -210,14 +210,14 @@ class ChargeampsChargePointSensor(ChargeAmpsEntity, RestoreSensor):
         """Restore last known state into the coordinator watermark on startup."""
         await super().async_added_to_hass()
         if self.entity_description.key == "total_energy" and (last := await self.async_get_last_sensor_data()):
-                try:
-                    restored = float(last.native_value)
-                except (TypeError, ValueError):
-                    return
-                cp_id = self.charge_point_id
-                if restored > self.coordinator._total_energy_max.get(cp_id, 0.0):
-                    self.coordinator._total_energy_max[cp_id] = restored
-                    self.coordinator.data["total_energy"][cp_id] = restored
+            try:
+                restored = float(last.native_value)
+            except (TypeError, ValueError):
+                return
+            cp_id = self.charge_point_id
+            if restored > self.coordinator._total_energy_max.get(cp_id, 0.0):
+                self.coordinator._total_energy_max[cp_id] = restored
+                self.coordinator.data["total_energy"][cp_id] = restored
 
     @property
     def native_value(self) -> float | None:

--- a/custom_components/chargeamps/translations/en.json
+++ b/custom_components/chargeamps/translations/en.json
@@ -110,6 +110,9 @@
     "button": {
       "reboot": {
         "name": "Reboot"
+      },
+      "recalculate_total_energy": {
+        "name": "Recalculate total energy"
       }
     },
     "light": {


### PR DESCRIPTION
Fixes #102.

## Root cause

`total_consumption_kwh` in the Charge Amps connector status represents the **current session's energy only** — it resets to 0 when a session ends. The v2.0.0 rewrite introduced a dedicated `total_energy` chargepoint sensor that passed this value through directly, so the sensor dropped to zero after every charge.

## Changes

**High-watermark in coordinator** (`coordinator.py`)
The coordinator now tracks the maximum seen value per charge point (`_total_energy_max`). During normal polling the sensor value only ever increases, never drops back to 0 between sessions.

**Restore last state across restarts** (`sensor.py`)
`ChargeampsChargePointSensor` now extends `RestoreSensor`. On HA startup it restores the last known value from HA's state machine and seeds the watermark with it, so a restart between sessions doesn't reset the counter.

**"Recalculate total energy" diagnostic button** (`button.py`, `translations/en.json`)
A new diagnostic button fetches the full session history from the Charge Amps API (sum of all completed sessions + any ongoing session energy, de-duplicated by session ID) and sets that as the new watermark. Users affected by the v2.0.0 regression can press this once to recover their correct historical total without needing to touch the HA statistics database.

## Notes

- The watermark is in-memory only; `RestoreSensor` covers the restart case.
- The sessions API history depth is unknown — if Charge Amps caps how far back it returns sessions, the recalculated total may not include very old data.
- HA's long-term statistics for `TOTAL_INCREASING` likely preserved cumulative totals correctly across the resets (it offsets on decrease), so the Energy Dashboard may already be accurate for most users. The raw sensor state showing 0 between sessions is the main visible symptom.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced "Recalculate total energy" button enabling users to recalculate energy consumption from complete charging session history.
  * Total energy sensors now support state restoration, preserving historical values through system restarts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->