### PR TITLE
Make webhook secret deterministic and allow override

### DIFF
--- a/custom_components/chargeamps/__init__.py
+++ b/custom_components/chargeamps/__init__.py
@@ -1,7 +1,7 @@
 """Component to integrate with Chargeamps."""
 
+import hashlib
 import logging
-import secrets
 from datetime import timedelta
 from typing import Optional
 
@@ -100,7 +100,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     # Generate webhook secret on first setup and notify the user
     if CONF_WEBHOOK_SECRET not in entry.data:
-        secret = secrets.token_hex(32)
+        secret = hashlib.sha256(entry.data[CONF_API_KEY].encode()).hexdigest()
         hass.config_entries.async_update_entry(entry, data={**entry.data, CONF_WEBHOOK_SECRET: secret})
         notify_create(
             hass,

--- a/custom_components/chargeamps/config_flow.py
+++ b/custom_components/chargeamps/config_flow.py
@@ -20,7 +20,7 @@ from homeassistant.helpers import selector
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .client import ChargeAmpsClient
-from .const import CONF_CHARGEPOINTS, DEFAULT_SCAN_INTERVAL, DOMAIN
+from .const import CONF_CHARGEPOINTS, CONF_WEBHOOK_SECRET, DEFAULT_SCAN_INTERVAL, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -30,6 +30,7 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
         vol.Required(CONF_PASSWORD): str,
         vol.Required(CONF_API_KEY): str,
         vol.Optional(CONF_URL): str,
+        vol.Optional(CONF_WEBHOOK_SECRET): str,
     }
 )
 
@@ -72,6 +73,8 @@ class ChargeAmpsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             await self.async_set_unique_id(user_input[CONF_EMAIL].lower())
             self._abort_if_unique_id_configured()
 
+            if not user_input.get(CONF_WEBHOOK_SECRET):
+                user_input.pop(CONF_WEBHOOK_SECRET, None)
             try:
                 info = await validate_input(self.hass, user_input)
             except Exception:  # pylint: disable=broad-except
@@ -107,6 +110,8 @@ class ChargeAmpsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Confirm re-authentication."""
         errors: dict[str, str] = {}
         if user_input is not None:
+            if not user_input.get(CONF_WEBHOOK_SECRET):
+                user_input.pop(CONF_WEBHOOK_SECRET, None)
             try:
                 await validate_input(self.hass, user_input)
             except Exception:

--- a/custom_components/chargeamps/translations/en.json
+++ b/custom_components/chargeamps/translations/en.json
@@ -10,7 +10,8 @@
           "email": "Email",
           "password": "Password",
           "api_key": "API Key",
-          "url": "API Base URL (optional)"
+          "url": "API Base URL (optional)",
+          "webhook_secret": "Webhook secret (optional — leave blank to auto-derive from API key)"
         }
       },
       "reauth_confirm": {
@@ -20,7 +21,8 @@
           "email": "Email",
           "password": "Password",
           "api_key": "API Key",
-          "url": "API Base URL (optional)"
+          "url": "API Base URL (optional)",
+          "webhook_secret": "Webhook secret (optional — leave blank to keep existing)"
         }
       }
     },


### PR DESCRIPTION
## Summary

- Replaces the random `secrets.token_hex(32)` webhook secret with a SHA-256 hash of the user's ChargeAmps API key, so the value is stable across reinstalls
- Adds an optional **Webhook secret** field to the setup and reauth flows for users who need a specific value
- Existing entries are unaffected — the secret is only generated when absent from `entry.data`

Closes #101

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional webhook secret field to configuration; automatically derives from API key when not provided
  * Added optional API Base URL field for custom endpoint configuration  
  * Re-authentication flow now preserves existing webhook secret settings unless explicitly modified

<!-- end of auto-generated comment: release notes by coderabbit.ai -->