### PR TITLE
Fix options flow 500 error on HA 2025.12+

### DIFF
--- a/custom_components/chargeamps/config_flow.py
+++ b/custom_components/chargeamps/config_flow.py
@@ -64,7 +64,7 @@ class ChargeAmpsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         config_entry: config_entries.ConfigEntry,
     ) -> ChargeAmpsOptionsFlowHandler:
         """Get the options flow for this handler."""
-        return ChargeAmpsOptionsFlowHandler(config_entry)
+        return ChargeAmpsOptionsFlowHandler()
 
     async def async_step_user(self, user_input: dict[str, Any] | None = None) -> FlowResult:
         """Handle the initial step."""
@@ -133,10 +133,6 @@ class ChargeAmpsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
 class ChargeAmpsOptionsFlowHandler(config_entries.OptionsFlow):
     """Handle options flow for Chargeamps."""
-
-    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
-        """Initialize options flow."""
-        self.config_entry = config_entry
 
     async def async_step_init(self, user_input: dict[str, Any] | None = None) -> FlowResult:
         """Manage the options."""


### PR DESCRIPTION
## Summary

- Removes the custom `__init__` on `ChargeAmpsOptionsFlowHandler` that set `self.config_entry` explicitly
- HA 2025.12 made `config_entry` a read-only property on `OptionsFlow`, causing a 500 error when opening the Configure dialog
- HA injects `config_entry` automatically, so `self.config_entry` continues to work in all step methods

Fixes #100

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the Chargeamps integration's configuration options flow to streamline how settings are managed. This internal restructuring improves the configuration handling without changing user-visible settings or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->