### PR TITLE
Fix KeyError in total energy watermark on first poll

### DIFF
--- a/custom_components/chargeamps/coordinator.py
+++ b/custom_components/chargeamps/coordinator.py
@@ -82,11 +82,10 @@ class ChargeAmpsDataUpdateCoordinator(DataUpdateCoordinator):
 
                 # Calculate total energy — use a high watermark so the sensor doesn't
                 # drop to 0 between sessions (total_consumption_kwh resets per session).
-                live_total = round(sum(cs.total_consumption_kwh for cs in status.connector_statuses), 2)
-                prev_max = self._total_energy_max.get(cp.id, 0.0)
-                if live_total > prev_max:
-                    self._total_energy_max[cp.id] = live_total
-                data["total_energy"][cp.id] = self._total_energy_max[cp.id]
+                live_total = round(sum((cs.total_consumption_kwh or 0.0) for cs in status.connector_statuses), 2)
+                new_max = max(live_total, self._total_energy_max.get(cp.id, 0.0))
+                self._total_energy_max[cp.id] = new_max
+                data["total_energy"][cp.id] = new_max
 
             # Process all charge points in parallel
             await asyncio.gather(*(fetch_cp_data(cp) for cp in chargepoints))


### PR DESCRIPTION
When a charger is idle at startup, `total_consumption_kwh` sums to `0.0`, so the `if live_total > prev_max` condition was false and `_total_energy_max[cp.id]` was never written — but the next line tried to read it, causing a `KeyError` on every update.

Replaced the conditional with `max()` so the key is always written. Also added an `or 0.0` guard in case the API returns `None` for `total_consumption_kwh`.

Fixes #108

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Bug Fixes**
- Improved reliability of total energy calculations for charge points by enhancing data handling for edge cases. The system now maintains consistent, non-decreasing energy values throughout the tracking lifecycle, providing more accurate energy monitoring and reporting across all charge points.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->