### PR TITLE
Fix remote stop/reboot JSON body and metervalue falsy-guard bugs

### DIFF
--- a/custom_components/chargeamps/__init__.py
+++ b/custom_components/chargeamps/__init__.py
@@ -328,15 +328,20 @@ class ChargeAmpsCallbackView(HomeAssistantView):
             for mv in data.get("meterValueList", []):
                 conn_id = mv.get("connectorId")
                 total_kwh = mv.get("totalConsumptionKWh")
+                raw_measurements = mv.get("measurements")
+                parsed_measurements = (
+                    [ChargePointMeasurement.model_validate(m) for m in raw_measurements]
+                    if raw_measurements is not None
+                    else None
+                )
                 status = coordinator.data["status"].get(chargepoint_id)
                 if not status:
                     continue
                 new_statuses = [
                     cs.model_copy(
                         update={
-                            "total_consumption_kwh": total_kwh or cs.total_consumption_kwh,
-                            "measurements": [ChargePointMeasurement.model_validate(m) for m in mv.get("measurements") or []]
-                            or cs.measurements,
+                            "total_consumption_kwh": total_kwh if total_kwh is not None else cs.total_consumption_kwh,
+                            "measurements": parsed_measurements if parsed_measurements is not None else cs.measurements,
                         }
                     )
                     if cs.connector_id == conn_id

--- a/custom_components/chargeamps/__init__.py
+++ b/custom_components/chargeamps/__init__.py
@@ -330,9 +330,7 @@ class ChargeAmpsCallbackView(HomeAssistantView):
                 total_kwh = mv.get("totalConsumptionKWh")
                 raw_measurements = mv.get("measurements")
                 parsed_measurements = (
-                    [ChargePointMeasurement.model_validate(m) for m in raw_measurements]
-                    if raw_measurements is not None
-                    else None
+                    [ChargePointMeasurement.model_validate(m) for m in raw_measurements] if raw_measurements is not None else None
                 )
                 status = coordinator.data["status"].get(chargepoint_id)
                 if not status:

--- a/custom_components/chargeamps/client.py
+++ b/custom_components/chargeamps/client.py
@@ -319,9 +319,9 @@ class ChargeAmpsClient:
     async def remote_stop(self, charge_point_id: str, connector_id: int) -> None:
         """Remote stop chargepoint."""
         request_uri = f"/api/{API_VERSION}/chargepoints/{charge_point_id}/connectors/{connector_id}/remotestop"
-        await self._put(request_uri, json="{}")
+        await self._put(request_uri, json={})
 
     async def reboot(self, charge_point_id) -> None:
         """Reboot chargepoint."""
         request_uri = f"/api/{API_VERSION}/chargepoints/{charge_point_id}/reboot"
-        await self._put(request_uri, json="{}")
+        await self._put(request_uri, json={})


### PR DESCRIPTION
## Summary

- `remote_stop` and `reboot` in `client.py` were passing `json="{}"` (a Python string) to aiohttp, which serialises it as the JSON string `"\"{}\""` instead of an empty object `{}`. Fixed both to `json={}`.
- In the metervalue webhook handler, falsy-`or` guards on `total_kwh` and the parsed measurements list would silently discard valid `0.0` values and empty arrays. Replaced with explicit `is not None` checks so the coordinator always applies what the API actually sent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed API request payload formatting for remote stop and reboot operations.
  
* **Improvements**
  * Enhanced measurement data handling and validation to ensure more accurate connector status information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->