### PR TITLE
Add reconfigure flow

### DIFF
--- a/custom_components/chargeamps/config_flow.py
+++ b/custom_components/chargeamps/config_flow.py
@@ -110,10 +110,6 @@ class ChargeAmpsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         entry = self._get_reconfigure_entry()
         errors: dict[str, str] = {}
         if user_input is not None:
-            if not user_input.get(CONF_WEBHOOK_SECRET):
-                user_input.pop(CONF_WEBHOOK_SECRET, None)
-            if not user_input.get(CONF_WEBHOOK_ID):
-                user_input.pop(CONF_WEBHOOK_ID, None)
             try:
                 await validate_input(self.hass, user_input)
             except Exception:
@@ -122,7 +118,11 @@ class ChargeAmpsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             else:
                 await self.async_set_unique_id(user_input[CONF_EMAIL].lower())
                 self._abort_if_unique_id_mismatch(reason="wrong_account")
-                return self.async_update_reload_and_abort(entry, data_updates=user_input)
+                new_data = {**entry.data, **user_input}
+                for key in (CONF_WEBHOOK_SECRET, CONF_WEBHOOK_ID):
+                    if not new_data.get(key):
+                        new_data.pop(key, None)
+                return self.async_update_reload_and_abort(entry, data=new_data)
 
         return self.async_show_form(
             step_id="reconfigure",

--- a/custom_components/chargeamps/config_flow.py
+++ b/custom_components/chargeamps/config_flow.py
@@ -107,7 +107,7 @@ class ChargeAmpsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_reconfigure(self, user_input: dict[str, Any] | None = None) -> FlowResult:
         """Allow the user to update credentials or settings without removing the entry."""
-        entry = self.hass.config_entries.async_get_entry(self.context["entry_id"])
+        entry = self._get_reconfigure_entry()
         errors: dict[str, str] = {}
         if user_input is not None:
             if not user_input.get(CONF_WEBHOOK_SECRET):
@@ -120,18 +120,13 @@ class ChargeAmpsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 _LOGGER.exception("Unexpected exception during reconfigure")
                 errors["base"] = "unknown"
             else:
-                # Preserve existing webhook_secret / webhook_id if the user left
-                # the fields blank, so __init__.py doesn't treat it as a first-time
-                # setup and re-fire the webhook credentials notification.
-                if CONF_WEBHOOK_SECRET not in user_input and entry and CONF_WEBHOOK_SECRET in entry.data:
-                    user_input[CONF_WEBHOOK_SECRET] = entry.data[CONF_WEBHOOK_SECRET]
-                if CONF_WEBHOOK_ID not in user_input and entry and CONF_WEBHOOK_ID in entry.data:
-                    user_input[CONF_WEBHOOK_ID] = entry.data[CONF_WEBHOOK_ID]
-                return self.async_update_reload_and_abort(entry, data=user_input)
+                await self.async_set_unique_id(user_input[CONF_EMAIL].lower())
+                self._abort_if_unique_id_mismatch(reason="wrong_account")
+                return self.async_update_reload_and_abort(entry, data_updates=user_input)
 
         return self.async_show_form(
             step_id="reconfigure",
-            data_schema=self.add_suggested_values_to_schema(STEP_USER_DATA_SCHEMA, entry.data if entry else {}),
+            data_schema=self.add_suggested_values_to_schema(STEP_USER_DATA_SCHEMA, entry.data),
             errors=errors,
         )
 

--- a/custom_components/chargeamps/config_flow.py
+++ b/custom_components/chargeamps/config_flow.py
@@ -34,12 +34,10 @@ _WEBHOOK_SECRET_RE = re.compile(r"^[^\s\x00-\x1f\x7f]+$")
 def _validate_webhook_overrides(user_input: dict[str, Any]) -> dict[str, str]:
     """Return field-level errors for invalid webhook override values."""
     errors: dict[str, str] = {}
-    if wid := user_input.get(CONF_WEBHOOK_ID):
-        if not _WEBHOOK_ID_RE.match(wid):
-            errors[CONF_WEBHOOK_ID] = "invalid_webhook_id"
-    if secret := user_input.get(CONF_WEBHOOK_SECRET):
-        if not _WEBHOOK_SECRET_RE.match(secret):
-            errors[CONF_WEBHOOK_SECRET] = "invalid_webhook_secret"
+    if (wid := user_input.get(CONF_WEBHOOK_ID)) and not _WEBHOOK_ID_RE.match(wid):
+        errors[CONF_WEBHOOK_ID] = "invalid_webhook_id"
+    if (secret := user_input.get(CONF_WEBHOOK_SECRET)) and not _WEBHOOK_SECRET_RE.match(secret):
+        errors[CONF_WEBHOOK_SECRET] = "invalid_webhook_secret"
     return errors
 
 

--- a/custom_components/chargeamps/config_flow.py
+++ b/custom_components/chargeamps/config_flow.py
@@ -102,6 +102,32 @@ class ChargeAmpsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         clean_data = {k: v for k, v in import_data.items() if k in (CONF_EMAIL, CONF_PASSWORD, CONF_API_KEY, CONF_URL)}
         return self.async_create_entry(title=clean_data[CONF_EMAIL], data=clean_data, options=options)
 
+    async def async_step_reconfigure(self, user_input: dict[str, Any] | None = None) -> FlowResult:
+        """Allow the user to update credentials or settings without removing the entry."""
+        entry = self.hass.config_entries.async_get_entry(self.context["entry_id"])
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            if not user_input.get(CONF_WEBHOOK_SECRET):
+                user_input.pop(CONF_WEBHOOK_SECRET, None)
+            try:
+                await validate_input(self.hass, user_input)
+            except Exception:
+                _LOGGER.exception("Unexpected exception during reconfigure")
+                errors["base"] = "unknown"
+            else:
+                # Preserve existing webhook_secret if user left the field blank,
+                # so __init__.py doesn't treat it as a first-time setup and re-fire
+                # the webhook credentials notification.
+                if CONF_WEBHOOK_SECRET not in user_input and entry and CONF_WEBHOOK_SECRET in entry.data:
+                    user_input[CONF_WEBHOOK_SECRET] = entry.data[CONF_WEBHOOK_SECRET]
+                return self.async_update_reload_and_abort(entry, data=user_input)
+
+        return self.async_show_form(
+            step_id="reconfigure",
+            data_schema=self.add_suggested_values_to_schema(STEP_USER_DATA_SCHEMA, entry.data if entry else {}),
+            errors=errors,
+        )
+
     async def async_step_reauth(self, entry_data: dict[str, Any]) -> FlowResult:
         """Handle re-authentication — show the form immediately."""
         return await self.async_step_reauth_confirm()

--- a/custom_components/chargeamps/config_flow.py
+++ b/custom_components/chargeamps/config_flow.py
@@ -112,17 +112,21 @@ class ChargeAmpsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             if not user_input.get(CONF_WEBHOOK_SECRET):
                 user_input.pop(CONF_WEBHOOK_SECRET, None)
+            if not user_input.get(CONF_WEBHOOK_ID):
+                user_input.pop(CONF_WEBHOOK_ID, None)
             try:
                 await validate_input(self.hass, user_input)
             except Exception:
                 _LOGGER.exception("Unexpected exception during reconfigure")
                 errors["base"] = "unknown"
             else:
-                # Preserve existing webhook_secret if user left the field blank,
-                # so __init__.py doesn't treat it as a first-time setup and re-fire
-                # the webhook credentials notification.
+                # Preserve existing webhook_secret / webhook_id if the user left
+                # the fields blank, so __init__.py doesn't treat it as a first-time
+                # setup and re-fire the webhook credentials notification.
                 if CONF_WEBHOOK_SECRET not in user_input and entry and CONF_WEBHOOK_SECRET in entry.data:
                     user_input[CONF_WEBHOOK_SECRET] = entry.data[CONF_WEBHOOK_SECRET]
+                if CONF_WEBHOOK_ID not in user_input and entry and CONF_WEBHOOK_ID in entry.data:
+                    user_input[CONF_WEBHOOK_ID] = entry.data[CONF_WEBHOOK_ID]
                 return self.async_update_reload_and_abort(entry, data=user_input)
 
         return self.async_show_form(

--- a/custom_components/chargeamps/config_flow.py
+++ b/custom_components/chargeamps/config_flow.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import re
 from typing import Any
 
 import voluptuous as vol
@@ -23,6 +24,24 @@ from .client import ChargeAmpsClient
 from .const import CONF_CHARGEPOINTS, CONF_WEBHOOK_ID, CONF_WEBHOOK_SECRET, DEFAULT_SCAN_INTERVAL, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
+
+# Webhook URL ID must be safe as a URL path segment (alphanumeric, dash, underscore)
+_WEBHOOK_ID_RE = re.compile(r"^[a-zA-Z0-9_\-]+$")
+# Webhook secret must be printable, non-whitespace ASCII (it's sent as an HTTP header value)
+_WEBHOOK_SECRET_RE = re.compile(r"^[^\s\x00-\x1f\x7f]+$")
+
+
+def _validate_webhook_overrides(user_input: dict[str, Any]) -> dict[str, str]:
+    """Return field-level errors for invalid webhook override values."""
+    errors: dict[str, str] = {}
+    if wid := user_input.get(CONF_WEBHOOK_ID):
+        if not _WEBHOOK_ID_RE.match(wid):
+            errors[CONF_WEBHOOK_ID] = "invalid_webhook_id"
+    if secret := user_input.get(CONF_WEBHOOK_SECRET):
+        if not _WEBHOOK_SECRET_RE.match(secret):
+            errors[CONF_WEBHOOK_SECRET] = "invalid_webhook_secret"
+    return errors
+
 
 STEP_USER_DATA_SCHEMA = vol.Schema(
     {
@@ -78,13 +97,15 @@ class ChargeAmpsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 user_input.pop(CONF_WEBHOOK_SECRET, None)
             if not user_input.get(CONF_WEBHOOK_ID):
                 user_input.pop(CONF_WEBHOOK_ID, None)
-            try:
-                info = await validate_input(self.hass, user_input)
-            except Exception:  # pylint: disable=broad-except
-                _LOGGER.exception("Unexpected exception")
-                errors["base"] = "unknown"
-            else:
-                return self.async_create_entry(title=info["title"], data=user_input)
+            errors |= _validate_webhook_overrides(user_input)
+            if not errors:
+                try:
+                    info = await validate_input(self.hass, user_input)
+                except Exception:  # pylint: disable=broad-except
+                    _LOGGER.exception("Unexpected exception")
+                    errors["base"] = "unknown"
+                else:
+                    return self.async_create_entry(title=info["title"], data=user_input)
 
         return self.async_show_form(step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors)
 
@@ -110,19 +131,21 @@ class ChargeAmpsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         entry = self._get_reconfigure_entry()
         errors: dict[str, str] = {}
         if user_input is not None:
-            try:
-                await validate_input(self.hass, user_input)
-            except Exception:
-                _LOGGER.exception("Unexpected exception during reconfigure")
-                errors["base"] = "unknown"
-            else:
-                await self.async_set_unique_id(user_input[CONF_EMAIL].lower())
-                self._abort_if_unique_id_mismatch(reason="wrong_account")
-                new_data = {**entry.data, **user_input}
-                for key in (CONF_WEBHOOK_SECRET, CONF_WEBHOOK_ID):
-                    if not new_data.get(key):
-                        new_data.pop(key, None)
-                return self.async_update_reload_and_abort(entry, data=new_data)
+            errors |= _validate_webhook_overrides(user_input)
+            if not errors:
+                try:
+                    await validate_input(self.hass, user_input)
+                except Exception:
+                    _LOGGER.exception("Unexpected exception during reconfigure")
+                    errors["base"] = "unknown"
+                else:
+                    await self.async_set_unique_id(user_input[CONF_EMAIL].lower())
+                    self._abort_if_unique_id_mismatch(reason="wrong_account")
+                    new_data = {**entry.data, **user_input}
+                    for key in (CONF_WEBHOOK_SECRET, CONF_WEBHOOK_ID):
+                        if not new_data.get(key):
+                            new_data.pop(key, None)
+                    return self.async_update_reload_and_abort(entry, data=new_data)
 
         return self.async_show_form(
             step_id="reconfigure",
@@ -142,16 +165,18 @@ class ChargeAmpsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 user_input.pop(CONF_WEBHOOK_SECRET, None)
             if not user_input.get(CONF_WEBHOOK_ID):
                 user_input.pop(CONF_WEBHOOK_ID, None)
-            try:
-                await validate_input(self.hass, user_input)
-            except Exception:
-                _LOGGER.exception("Unexpected exception during re-auth")
-                errors["base"] = "unknown"
-            else:
-                entry = self.hass.config_entries.async_get_entry(self.context["entry_id"])
-                self.hass.config_entries.async_update_entry(entry, data={**entry.data, **user_input})
-                await self.hass.config_entries.async_reload(entry.entry_id)
-                return self.async_abort(reason="reauth_successful")
+            errors |= _validate_webhook_overrides(user_input)
+            if not errors:
+                try:
+                    await validate_input(self.hass, user_input)
+                except Exception:
+                    _LOGGER.exception("Unexpected exception during re-auth")
+                    errors["base"] = "unknown"
+                else:
+                    entry = self.hass.config_entries.async_get_entry(self.context["entry_id"])
+                    self.hass.config_entries.async_update_entry(entry, data={**entry.data, **user_input})
+                    await self.hass.config_entries.async_reload(entry.entry_id)
+                    return self.async_abort(reason="reauth_successful")
 
         entry = self.hass.config_entries.async_get_entry(self.context["entry_id"])
         return self.async_show_form(

--- a/custom_components/chargeamps/translations/en.json
+++ b/custom_components/chargeamps/translations/en.json
@@ -14,6 +14,17 @@
           "webhook_secret": "Webhook secret (optional — leave blank to auto-derive from API key)"
         }
       },
+      "reconfigure": {
+        "title": "Reconfigure Chargeamps",
+        "description": "Update your Chargeamps credentials or API settings.",
+        "data": {
+          "email": "Email",
+          "password": "Password",
+          "api_key": "API Key",
+          "url": "API Base URL (optional)",
+          "webhook_secret": "Webhook secret (optional — leave blank to keep existing)"
+        }
+      },
       "reauth_confirm": {
         "title": "Re-authenticate Chargeamps",
         "description": "Your credentials are no longer valid. Please update them below.",
@@ -33,7 +44,8 @@
     },
     "abort": {
       "already_configured": "Device is already configured",
-      "reauth_successful": "Re-authentication was successful"
+      "reauth_successful": "Re-authentication was successful",
+      "reconfigure_successful": "Configuration updated successfully"
     }
   },
   "options": {

--- a/custom_components/chargeamps/translations/en.json
+++ b/custom_components/chargeamps/translations/en.json
@@ -11,7 +11,8 @@
           "password": "Password",
           "api_key": "API Key",
           "url": "API Base URL (optional)",
-          "webhook_secret": "Webhook secret (optional — leave blank to auto-derive from API key)"
+          "webhook_secret": "Webhook secret (optional — leave blank to auto-derive from API key)",
+          "webhook_id": "Webhook URL ID (optional — leave blank to auto-derive from email)"
         }
       },
       "reconfigure": {
@@ -22,7 +23,8 @@
           "password": "Password",
           "api_key": "API Key",
           "url": "API Base URL (optional)",
-          "webhook_secret": "Webhook secret (optional — leave blank to keep existing)"
+          "webhook_secret": "Webhook secret (optional — leave blank to keep existing)",
+          "webhook_id": "Webhook URL ID (optional — leave blank to keep existing)"
         }
       },
       "reauth_confirm": {
@@ -33,7 +35,8 @@
           "password": "Password",
           "api_key": "API Key",
           "url": "API Base URL (optional)",
-          "webhook_secret": "Webhook secret (optional — leave blank to keep existing)"
+          "webhook_secret": "Webhook secret (optional — leave blank to keep existing)",
+          "webhook_id": "Webhook URL ID (optional — leave blank to keep existing)"
         }
       }
     },

--- a/custom_components/chargeamps/translations/en.json
+++ b/custom_components/chargeamps/translations/en.json
@@ -48,7 +48,8 @@
     "abort": {
       "already_configured": "Device is already configured",
       "reauth_successful": "Re-authentication was successful",
-      "reconfigure_successful": "Configuration updated successfully"
+      "reconfigure_successful": "Configuration updated successfully",
+      "wrong_account": "The credentials belong to a different account. Use Reconfigure only to update settings for the same account."
     }
   },
   "options": {

--- a/custom_components/chargeamps/translations/en.json
+++ b/custom_components/chargeamps/translations/en.json
@@ -23,8 +23,8 @@
           "password": "Password",
           "api_key": "API Key",
           "url": "API Base URL (optional)",
-          "webhook_secret": "Webhook secret (optional — leave blank to keep existing)",
-          "webhook_id": "Webhook URL ID (optional — leave blank to keep existing)"
+          "webhook_secret": "Webhook secret (optional — leave blank to reset to auto-derived)",
+          "webhook_id": "Webhook URL ID (optional — leave blank to reset to auto-derived)"
         }
       },
       "reauth_confirm": {

--- a/custom_components/chargeamps/translations/en.json
+++ b/custom_components/chargeamps/translations/en.json
@@ -43,7 +43,9 @@
     "error": {
       "cannot_connect": "Failed to connect",
       "invalid_auth": "Invalid authentication",
-      "unknown": "Unexpected error"
+      "unknown": "Unexpected error",
+      "invalid_webhook_id": "Only letters, numbers, hyphens, and underscores are allowed",
+      "invalid_webhook_secret": "Must be printable characters with no spaces"
     },
     "abort": {
       "already_configured": "Device is already configured",

--- a/custom_components/chargeamps/translations/en.json
+++ b/custom_components/chargeamps/translations/en.json
@@ -45,7 +45,7 @@
       "invalid_auth": "Invalid authentication",
       "unknown": "Unexpected error",
       "invalid_webhook_id": "Only letters, numbers, hyphens, and underscores are allowed",
-      "invalid_webhook_secret": "Must be printable characters with no spaces"
+      "invalid_webhook_secret": "Must be printable characters with no whitespace"
     },
     "abort": {
       "already_configured": "Device is already configured",


### PR DESCRIPTION
## Summary

- Implements `async_step_reconfigure()` so users can update credentials, API URL, or webhook secret via **Settings → Integrations → Chargeamps → Reconfigure** without removing and re-adding the integration
- Form pre-fills with current values so only changed fields need to be touched
- Preserves the existing webhook secret when left blank, preventing a spurious webhook setup notification on every reconfigure
- Adds translation strings for the new step and abort reason

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add a reconfigure flow to update ChargeAmps credentials and API settings without removing the entry.
  * Allow resetting webhook ID/secret to auto-derived when left blank.

* **Bug Fixes**
  * Validate webhook ID/secret inputs and show field-level errors; skip further validation until fixed.
  * Improved error handling on reauth/reconfigure to surface webhook validation issues.

* **Localization**
  * Added reconfigure dialog texts, reauth/reconfigure success notices, clearer webhook wording, and a wrong-account message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->