### PR TITLE
Make webhook URL segment stable across reinstalls

### DIFF
--- a/custom_components/chargeamps/__init__.py
+++ b/custom_components/chargeamps/__init__.py
@@ -30,6 +30,7 @@ from .client import (
 )
 from .const import (
     CONF_CHARGEPOINTS,
+    CONF_WEBHOOK_ID,
     CONF_WEBHOOK_SECRET,
     CONFIGURATION_URL,
     DEFAULT_SCAN_INTERVAL,
@@ -96,7 +97,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     except NoURLAvailableError:
         base_url = "<your-ha-external-url>"
 
-    webhook_base = f"{base_url}/api/chargeamps/{entry.entry_id}"
+    webhook_base = f"{base_url}/api/chargeamps/{_webhook_url_segment(entry)}"
 
     # Generate webhook secret on first setup and notify the user
     if CONF_WEBHOOK_SECRET not in entry.data:
@@ -264,6 +265,37 @@ def _get_coordinator_for_entry(hass: HomeAssistant, entry_id: str):
     return hass.data.get(DOMAIN, {}).get(entry_id)
 
 
+def _webhook_url_segment(entry: ConfigEntry) -> str:
+    """Return the URL segment for this entry's webhook paths.
+
+    Prefers an explicit override, then a stable SHA-256 of the unique_id
+    (lowercased email), and falls back to entry_id for legacy YAML-imported
+    entries that never got a unique_id.
+    """
+    return entry.data.get(CONF_WEBHOOK_ID) or (
+        hashlib.sha256(entry.unique_id.encode()).hexdigest() if entry.unique_id else entry.entry_id
+    )
+
+
+def _resolve_entry(hass: HomeAssistant, path_segment: str):
+    """Resolve a webhook URL segment to a ConfigEntry.
+
+    Accepts three forms (tried in order):
+      1. A raw HA entry UUID (old-style URLs — backwards compat)
+      2. An explicit CONF_WEBHOOK_ID override stored in entry.data
+      3. SHA-256 hex digest of entry.unique_id (new stable default)
+    """
+    entry = hass.config_entries.async_get_entry(path_segment)
+    if entry and entry.domain == DOMAIN:
+        return entry
+
+    for candidate in hass.config_entries.async_entries(DOMAIN):
+        if _webhook_url_segment(candidate) == path_segment:
+            return candidate
+
+    return None
+
+
 def _auth_ok(request, entry) -> bool:
     """Validate the x-api-key header against the stored webhook secret."""
     expected = entry.data.get(CONF_WEBHOOK_SECRET)
@@ -280,7 +312,7 @@ class ChargeAmpsHealthView(HomeAssistantView):
     async def get(self, request, entry_id: str):
         """Handle health-check GET request."""
         hass = request.app["hass"]
-        entry = hass.config_entries.async_get_entry(entry_id)
+        entry = _resolve_entry(hass, entry_id)
         if not entry or not _auth_ok(request, entry):
             return Response(status=401)
         return Response(status=200)
@@ -296,11 +328,11 @@ class ChargeAmpsCallbackView(HomeAssistantView):
     async def post(self, request, entry_id: str, chargepoint_id: str, event: str):
         """Handle charge point event callback POST request."""
         hass = request.app["hass"]
-        entry = hass.config_entries.async_get_entry(entry_id)
+        entry = _resolve_entry(hass, entry_id)
         if not entry or not _auth_ok(request, entry):
             return Response(status=401)
 
-        coordinator = _get_coordinator_for_entry(hass, entry_id)
+        coordinator = _get_coordinator_for_entry(hass, entry.entry_id)
         if not coordinator:
             return Response(status=503)
 
@@ -362,11 +394,11 @@ class ChargeAmpsConnectorCallbackView(HomeAssistantView):
     async def post(self, request, entry_id: str, chargepoint_id: str, connector_id: str, event: str):
         """Handle connector event callback POST request."""
         hass = request.app["hass"]
-        entry = hass.config_entries.async_get_entry(entry_id)
+        entry = _resolve_entry(hass, entry_id)
         if not entry or not _auth_ok(request, entry):
             return Response(status=401)
 
-        coordinator = _get_coordinator_for_entry(hass, entry_id)
+        coordinator = _get_coordinator_for_entry(hass, entry.entry_id)
         if not coordinator:
             return Response(status=503)
 

--- a/custom_components/chargeamps/config_flow.py
+++ b/custom_components/chargeamps/config_flow.py
@@ -20,7 +20,7 @@ from homeassistant.helpers import selector
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .client import ChargeAmpsClient
-from .const import CONF_CHARGEPOINTS, CONF_WEBHOOK_SECRET, DEFAULT_SCAN_INTERVAL, DOMAIN
+from .const import CONF_CHARGEPOINTS, CONF_WEBHOOK_ID, CONF_WEBHOOK_SECRET, DEFAULT_SCAN_INTERVAL, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -31,6 +31,7 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
         vol.Required(CONF_API_KEY): str,
         vol.Optional(CONF_URL): str,
         vol.Optional(CONF_WEBHOOK_SECRET): str,
+        vol.Optional(CONF_WEBHOOK_ID): str,
     }
 )
 
@@ -75,6 +76,8 @@ class ChargeAmpsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
             if not user_input.get(CONF_WEBHOOK_SECRET):
                 user_input.pop(CONF_WEBHOOK_SECRET, None)
+            if not user_input.get(CONF_WEBHOOK_ID):
+                user_input.pop(CONF_WEBHOOK_ID, None)
             try:
                 info = await validate_input(self.hass, user_input)
             except Exception:  # pylint: disable=broad-except
@@ -112,6 +115,8 @@ class ChargeAmpsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             if not user_input.get(CONF_WEBHOOK_SECRET):
                 user_input.pop(CONF_WEBHOOK_SECRET, None)
+            if not user_input.get(CONF_WEBHOOK_ID):
+                user_input.pop(CONF_WEBHOOK_ID, None)
             try:
                 await validate_input(self.hass, user_input)
             except Exception:

--- a/custom_components/chargeamps/const.py
+++ b/custom_components/chargeamps/const.py
@@ -44,6 +44,7 @@ ICON_MAP = {
 CONF_CHARGEPOINTS = "chargepoints"
 CONF_READONLY = "readonly"
 CONF_WEBHOOK_SECRET = "webhook_secret"
+CONF_WEBHOOK_ID = "webhook_id"
 
 # Webhook
 WEBHOOK_AUTH_HEADER = "x-api-key"

--- a/custom_components/chargeamps/diagnostics.py
+++ b/custom_components/chargeamps/diagnostics.py
@@ -10,6 +10,7 @@ from homeassistant.const import CONF_API_KEY, CONF_EMAIL, CONF_PASSWORD
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.network import NoURLAvailableError, get_url
 
+from . import _webhook_url_segment
 from .const import CONF_WEBHOOK_SECRET, DOMAIN, WEBHOOK_AUTH_HEADER
 
 REDACT_KEYS = {CONF_API_KEY, CONF_EMAIL, CONF_PASSWORD, CONF_WEBHOOK_SECRET, "password", "rfid"}
@@ -19,11 +20,12 @@ async def async_get_config_entry_diagnostics(hass: HomeAssistant, entry: ConfigE
     """Return diagnostics for a config entry."""
     coordinator = hass.data[DOMAIN][entry.entry_id]
 
+    url_segment = _webhook_url_segment(entry)
     try:
         base_url = get_url(hass, prefer_external=True)
-        webhook_base = f"{base_url}/api/chargeamps/{entry.entry_id}"
+        webhook_base = f"{base_url}/api/chargeamps/{url_segment}"
     except NoURLAvailableError:
-        webhook_base = f"<ha-external-url>/api/chargeamps/{entry.entry_id}"
+        webhook_base = f"<ha-external-url>/api/chargeamps/{url_segment}"
 
     return {
         "entry": {


### PR DESCRIPTION
## Summary

- The webhook URL previously used `entry_id` — a HA-internal UUID that changes on every reinstall, requiring users to contact Charge Amps support each time to update the registered URL
- The segment is now derived as `SHA-256(email)`, making it identical across reinstalls for the same account
- An optional **Webhook URL ID** field (mirrors the existing Webhook Secret override) lets users pin the segment to any value — e.g. their old `entry_id` — so existing webhook registrations keep working without any changes on the Charge Amps side
- Backwards compatible: handlers try a direct `entry_id` UUID lookup first (all existing installs), then fall back to override/hash matching

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional webhook ID configuration field during setup and re-authentication, allowing for custom webhook identification.

* **Improvements**
  * Enhanced webhook URL generation for improved stability and routing of callback requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->