### PR TITLE
Convert connector IDs to integers in service calls

### DIFF
--- a/custom_components/chargeamps/__init__.py
+++ b/custom_components/chargeamps/__init__.py
@@ -147,8 +147,8 @@ def setup_services(hass: HomeAssistant) -> None:
     async def async_set_max_current(call: ServiceCall):
         """Set the maximum charging current for a connector."""
         cp_id = call.data["chargepoint"]
-        conn_id = call.data["connector"]
-        max_curr = call.data["max_current"]
+        conn_id = int(call.data["connector"])
+        max_curr = int(call.data["max_current"])
 
         if 0 < max_curr < 6:
             _LOGGER.error("Invalid max_current %s: must be 0 or between 6 and 32", max_curr)
@@ -182,7 +182,7 @@ def setup_services(hass: HomeAssistant) -> None:
     async def async_enable_ev(call: ServiceCall):
         """Enable EV charging on a connector."""
         cp_id = call.data["chargepoint"]
-        conn_id = call.data["connector"]
+        conn_id = int(call.data["connector"])
         if coordinator := await get_coordinator(cp_id):
             settings = coordinator.data["connector_settings"].get((cp_id, conn_id))
             if settings:
@@ -193,7 +193,7 @@ def setup_services(hass: HomeAssistant) -> None:
     async def async_disable_ev(call: ServiceCall):
         """Disable EV charging on a connector."""
         cp_id = call.data["chargepoint"]
-        conn_id = call.data["connector"]
+        conn_id = int(call.data["connector"])
         if coordinator := await get_coordinator(cp_id):
             settings = coordinator.data["connector_settings"].get((cp_id, conn_id))
             if settings:
@@ -204,7 +204,7 @@ def setup_services(hass: HomeAssistant) -> None:
     async def async_cable_lock(call: ServiceCall):
         """Lock the cable on a connector."""
         cp_id = call.data["chargepoint"]
-        conn_id = call.data["connector"]
+        conn_id = int(call.data["connector"])
         if coordinator := await get_coordinator(cp_id):
             settings = coordinator.data["connector_settings"].get((cp_id, conn_id))
             if settings:
@@ -215,7 +215,7 @@ def setup_services(hass: HomeAssistant) -> None:
     async def async_cable_unlock(call: ServiceCall):
         """Unlock the cable on a connector."""
         cp_id = call.data["chargepoint"]
-        conn_id = call.data["connector"]
+        conn_id = int(call.data["connector"])
         if coordinator := await get_coordinator(cp_id):
             settings = coordinator.data["connector_settings"].get((cp_id, conn_id))
             if settings:
@@ -226,7 +226,7 @@ def setup_services(hass: HomeAssistant) -> None:
     async def async_remote_start(call: ServiceCall):
         """Remotely start a charging session on a connector."""
         cp_id = call.data["chargepoint"]
-        conn_id = call.data["connector"]
+        conn_id = int(call.data["connector"])
         auth = StartAuth(
             rfid_length=call.data.get("rfid_length", 4),
             rfid_format=call.data.get("rfid_format", "Dec"),
@@ -240,7 +240,7 @@ def setup_services(hass: HomeAssistant) -> None:
     async def async_remote_stop(call: ServiceCall):
         """Remotely stop a charging session on a connector."""
         cp_id = call.data["chargepoint"]
-        conn_id = call.data["connector"]
+        conn_id = int(call.data["connector"])
         if coordinator := await get_coordinator(cp_id):
             await coordinator.client.remote_stop(cp_id, conn_id)
             await coordinator.async_request_refresh()

--- a/custom_components/chargeamps/__init__.py
+++ b/custom_components/chargeamps/__init__.py
@@ -129,11 +129,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     return True
 
-
 def setup_services(hass: HomeAssistant) -> None:
     """Register services for Chargeamps."""
     if hass.services.has_service(DOMAIN, "set_max_current"):
         return
+
+    def _parse_int_field(call: ServiceCall, field: str) -> int | None:
+        try:
+            return int(call.data[field])
+        except (KeyError, TypeError, ValueError):
+            _LOGGER.error("Invalid %s value: %r", field, call.data.get(field))
+            return None
 
     async def get_coordinator(chargepoint_id: str) -> Optional[ChargeAmpsDataUpdateCoordinator]:
         """Find the coordinator matching a charge point ID."""
@@ -147,8 +153,14 @@ def setup_services(hass: HomeAssistant) -> None:
     async def async_set_max_current(call: ServiceCall):
         """Set the maximum charging current for a connector."""
         cp_id = call.data["chargepoint"]
-        conn_id = int(call.data["connector"])
-        max_curr = int(call.data["max_current"])
+        conn_id = _parse_int_field(call, "connector")
+        if conn_id is None:
+            _LOGGER.error("Invalid connector %s: must be an integer", conn_id)
+            return
+        max_curr = _parse_int_field(call, "max_current")
+        if max_curr is None:
+            _LOGGER.error("Invalid max_current %s: must be an integer", max_curr)
+            return
 
         if 0 < max_curr < 6:
             _LOGGER.error("Invalid max_current %s: must be 0 or between 6 and 32", max_curr)
@@ -182,7 +194,10 @@ def setup_services(hass: HomeAssistant) -> None:
     async def async_enable_ev(call: ServiceCall):
         """Enable EV charging on a connector."""
         cp_id = call.data["chargepoint"]
-        conn_id = int(call.data["connector"])
+        conn_id = _parse_int_field(call, "connector")
+        if conn_id is None:
+            _LOGGER.error("Invalid connector %s: must be an integer", conn_id)
+            return
         if coordinator := await get_coordinator(cp_id):
             settings = coordinator.data["connector_settings"].get((cp_id, conn_id))
             if settings:
@@ -193,7 +208,10 @@ def setup_services(hass: HomeAssistant) -> None:
     async def async_disable_ev(call: ServiceCall):
         """Disable EV charging on a connector."""
         cp_id = call.data["chargepoint"]
-        conn_id = int(call.data["connector"])
+        conn_id = _parse_int_field(call, "connector")
+        if conn_id is None:
+            _LOGGER.error("Invalid connector %s: must be an integer", conn_id)
+            return
         if coordinator := await get_coordinator(cp_id):
             settings = coordinator.data["connector_settings"].get((cp_id, conn_id))
             if settings:
@@ -204,7 +222,10 @@ def setup_services(hass: HomeAssistant) -> None:
     async def async_cable_lock(call: ServiceCall):
         """Lock the cable on a connector."""
         cp_id = call.data["chargepoint"]
-        conn_id = int(call.data["connector"])
+        conn_id = _parse_int_field(call, "connector")
+        if conn_id is None:
+            _LOGGER.error("Invalid connector %s: must be an integer", conn_id)
+            return
         if coordinator := await get_coordinator(cp_id):
             settings = coordinator.data["connector_settings"].get((cp_id, conn_id))
             if settings:
@@ -215,7 +236,10 @@ def setup_services(hass: HomeAssistant) -> None:
     async def async_cable_unlock(call: ServiceCall):
         """Unlock the cable on a connector."""
         cp_id = call.data["chargepoint"]
-        conn_id = int(call.data["connector"])
+        conn_id = _parse_int_field(call, "connector")
+        if conn_id is None:
+            _LOGGER.error("Invalid connector %s: must be an integer", conn_id)
+            return
         if coordinator := await get_coordinator(cp_id):
             settings = coordinator.data["connector_settings"].get((cp_id, conn_id))
             if settings:
@@ -226,7 +250,10 @@ def setup_services(hass: HomeAssistant) -> None:
     async def async_remote_start(call: ServiceCall):
         """Remotely start a charging session on a connector."""
         cp_id = call.data["chargepoint"]
-        conn_id = int(call.data["connector"])
+        conn_id = _parse_int_field(call, "connector")
+        if conn_id is None:
+            _LOGGER.error("Invalid connector %s: must be an integer", conn_id)
+            return
         auth = StartAuth(
             rfid_length=call.data.get("rfid_length", 4),
             rfid_format=call.data.get("rfid_format", "Dec"),
@@ -240,7 +267,10 @@ def setup_services(hass: HomeAssistant) -> None:
     async def async_remote_stop(call: ServiceCall):
         """Remotely stop a charging session on a connector."""
         cp_id = call.data["chargepoint"]
-        conn_id = int(call.data["connector"])
+        conn_id = _parse_int_field(call, "connector")
+        if conn_id is None:
+            _LOGGER.error("Invalid connector %s: must be an integer", conn_id)
+            return
         if coordinator := await get_coordinator(cp_id):
             await coordinator.client.remote_stop(cp_id, conn_id)
             await coordinator.async_request_refresh()

--- a/custom_components/chargeamps/__init__.py
+++ b/custom_components/chargeamps/__init__.py
@@ -154,12 +154,8 @@ def setup_services(hass: HomeAssistant) -> None:
         """Set the maximum charging current for a connector."""
         cp_id = call.data["chargepoint"]
         conn_id = _parse_int_field(call, "connector")
-        if conn_id is None:
-            _LOGGER.error("Invalid connector %s: must be an integer", conn_id)
-            return
         max_curr = _parse_int_field(call, "max_current")
-        if max_curr is None:
-            _LOGGER.error("Invalid max_current %s: must be an integer", max_curr)
+        if conn_id is None or max_curr is None:
             return
 
         if 0 < max_curr < 6:
@@ -196,7 +192,6 @@ def setup_services(hass: HomeAssistant) -> None:
         cp_id = call.data["chargepoint"]
         conn_id = _parse_int_field(call, "connector")
         if conn_id is None:
-            _LOGGER.error("Invalid connector %s: must be an integer", conn_id)
             return
         if coordinator := await get_coordinator(cp_id):
             settings = coordinator.data["connector_settings"].get((cp_id, conn_id))
@@ -210,7 +205,6 @@ def setup_services(hass: HomeAssistant) -> None:
         cp_id = call.data["chargepoint"]
         conn_id = _parse_int_field(call, "connector")
         if conn_id is None:
-            _LOGGER.error("Invalid connector %s: must be an integer", conn_id)
             return
         if coordinator := await get_coordinator(cp_id):
             settings = coordinator.data["connector_settings"].get((cp_id, conn_id))
@@ -224,7 +218,6 @@ def setup_services(hass: HomeAssistant) -> None:
         cp_id = call.data["chargepoint"]
         conn_id = _parse_int_field(call, "connector")
         if conn_id is None:
-            _LOGGER.error("Invalid connector %s: must be an integer", conn_id)
             return
         if coordinator := await get_coordinator(cp_id):
             settings = coordinator.data["connector_settings"].get((cp_id, conn_id))
@@ -238,7 +231,6 @@ def setup_services(hass: HomeAssistant) -> None:
         cp_id = call.data["chargepoint"]
         conn_id = _parse_int_field(call, "connector")
         if conn_id is None:
-            _LOGGER.error("Invalid connector %s: must be an integer", conn_id)
             return
         if coordinator := await get_coordinator(cp_id):
             settings = coordinator.data["connector_settings"].get((cp_id, conn_id))
@@ -252,7 +244,6 @@ def setup_services(hass: HomeAssistant) -> None:
         cp_id = call.data["chargepoint"]
         conn_id = _parse_int_field(call, "connector")
         if conn_id is None:
-            _LOGGER.error("Invalid connector %s: must be an integer", conn_id)
             return
         auth = StartAuth(
             rfid_length=call.data.get("rfid_length", 4),
@@ -269,7 +260,6 @@ def setup_services(hass: HomeAssistant) -> None:
         cp_id = call.data["chargepoint"]
         conn_id = _parse_int_field(call, "connector")
         if conn_id is None:
-            _LOGGER.error("Invalid connector %s: must be an integer", conn_id)
             return
         if coordinator := await get_coordinator(cp_id):
             await coordinator.client.remote_stop(cp_id, conn_id)


### PR DESCRIPTION
When using node-red, quotemarks are enforced for all parameters. This means they are interpreted as strings and not integers which makes the call fail.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation and error handling for connector and max-current inputs in charging controls. Invalid or missing values are now detected, logged, and actions aborted to prevent incorrect operations. This enhances stability across current adjustments, device enable/disable, cable lock/unlock, and remote start/stop.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hass-chargeamps/hass-chargeamps/pull/114)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->