### PR TITLE
Fix diagnostics crash caused by tuple keys in connector_settings

### DIFF
--- a/custom_components/chargeamps/__init__.py
+++ b/custom_components/chargeamps/__init__.py
@@ -129,6 +129,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     return True
 
+
 def setup_services(hass: HomeAssistant) -> None:
     """Register services for Chargeamps."""
     if hass.services.has_service(DOMAIN, "set_max_current"):

--- a/custom_components/chargeamps/diagnostics.py
+++ b/custom_components/chargeamps/diagnostics.py
@@ -27,6 +27,9 @@ async def async_get_config_entry_diagnostics(hass: HomeAssistant, entry: ConfigE
     except NoURLAvailableError:
         webhook_base = f"<ha-external-url>/api/chargeamps/{url_segment}"
 
+    data = dict(coordinator.data)
+    data["connector_settings"] = {f"{cp_id}/{conn_id}": v for (cp_id, conn_id), v in coordinator.data["connector_settings"].items()}
+
     return {
         "entry": {
             "title": entry.title,
@@ -38,5 +41,5 @@ async def async_get_config_entry_diagnostics(hass: HomeAssistant, entry: ConfigE
             "auth_header_key": WEBHOOK_AUTH_HEADER,
             "auth_header_value": "<redacted>" if entry.data.get(CONF_WEBHOOK_SECRET) else "not yet generated",
         },
-        "data": async_redact_data(coordinator.data, REDACT_KEYS),
+        "data": async_redact_data(data, REDACT_KEYS),
     }


### PR DESCRIPTION
## Summary

- `connector_settings` uses `(chargepoint_id, connector_id)` tuples as dict keys internally, which the JSON serializer cannot handle — causing the diagnostics download to crash for anyone with more than one connector.
- Converts the keys to `"chargepoint_id/connector_id"` strings before passing to `async_redact_data`.

Fixes #115