### PR TITLE
Release 2.3.0

### DIFF
--- a/custom_components/chargeamps/manifest.json
+++ b/custom_components/chargeamps/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/hass-chargeamps/hass-chargeamps/issues",
   "requirements": [],
-  "version": "2.2.0"
+  "version": "2.3.0"
 }


### PR DESCRIPTION
## What's changed

- **Add schedule mode switch per connector** (#121) — exposes a dedicated Schedule switch alongside the existing enable switch, letting users activate a charging schedule configured in the Charge Amps app from Home Assistant without losing the simple on/off toggle